### PR TITLE
feat: add custom validation options

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: ci-unit-tests
+name: CI
 
 on:
   push:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
         run: yarn build
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v2
-        if: matrix.node == '17'
+        if: matrix.node == '18'
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true

--- a/readme.md
+++ b/readme.md
@@ -45,7 +45,7 @@ The factory creates a `help()` function that can be used to print all available 
 import { createParser } from '@eegli/tinyparse';
 import assert from 'node:assert/strict';
 
-// Default values. These will be used as defaults/fallback
+// Default values. They will be used as defaults/fallbak
 const defaultValues = {
   username: '',
   hasGithubProfile: false,
@@ -64,10 +64,16 @@ const { help, parse } = createParser(
     // Options per key
     options: {
       username: {
-        // Fail if not present
         required: true,
         // For the help() command
         description: 'Your Github username',
+        // A custom validator that will receive the value for
+        // "username" and returns a boolean
+        customValidator: {
+          isValid: (value) => typeof value === 'string' && /\w+/.test(value),
+          // The error message for when validation fails
+          errorMessage: (value) => `${value} is not a valid GitHub username`,
+        },
       },
       hasGithubProfile: {
         description: 'Indicate whether you have a Github profile',

--- a/src/help.ts
+++ b/src/help.ts
@@ -1,37 +1,39 @@
-import { FilePathArg, InternalOption, SimpleRecord } from './types';
+import { FilePathArg, InternalOptions, SimpleRecord } from './types';
 
 type DisplayHelp = {
   defaultValues: SimpleRecord;
-  options: InternalOption[];
+  options?: InternalOptions;
   filePathArg?: FilePathArg;
   title?: string;
 };
 
 export const displayHelp = ({
   defaultValues,
-  options,
-  title,
+  options = new Map(),
+  title = 'Usage',
   filePathArg,
 }: DisplayHelp): string => {
   // Required properties first
-  options.sort((a, b) => (a.required === b.required ? 0 : a.required ? -1 : 1));
+  const opts = [...options.values()].sort((a, b) =>
+    a.required === b.required ? 0 : a.required ? -1 : 1
+  );
 
-  let str = `${title ? title : 'Usage'}`;
+  let str = title;
 
-  if (options.length > 0) {
+  if (opts.length > 0) {
     str += '\n\n';
   }
 
   // Maybe no option is required
-  if (options[0]?.required) {
+  if (opts[0]?.required) {
     str += 'Required\n';
   }
 
   let optionalFlag = true;
   const tab = '   ';
 
-  options.forEach(({ name, description, required, shortFlag }, idx) => {
-    const isLast = idx === options.length - 1;
+  opts.forEach(({ name, description, required, shortFlag }, idx) => {
+    const isLast = idx === opts.length - 1;
     const isBoolean = typeof defaultValues[name] === 'boolean';
 
     if (optionalFlag && !required) {

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -34,10 +34,10 @@ export async function parseObjectLiteral<T extends SimpleRecord>({
 
     if (customValidator) {
       // Coerced truthy values are ignored
-      if (customValidator.validate(argVal) === true) {
+      if (customValidator.isValid(argVal) === true) {
         config.set(arg, argVal);
       } else {
-        throw new ValidationError(customValidator.reason(argVal));
+        throw new ValidationError(customValidator.errorMessage(argVal));
       }
     }
 

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -34,9 +34,6 @@ export async function parseObjectLiteral<T extends SimpleRecord>({
       (v) => v.name === arg && v.customValidator
     )?.customValidator;
 
-    const expected = typeof defaultValues[arg];
-    const received = typeof argVal;
-
     if (customValidator) {
       if (customValidator.validate(argVal)) {
         config.set(arg, argVal);
@@ -44,6 +41,9 @@ export async function parseObjectLiteral<T extends SimpleRecord>({
         throw new ValidationError(customValidator.reason(argVal));
       }
     }
+
+    const expected = typeof defaultValues[arg];
+    const received = typeof argVal;
 
     // The received type must corresponds to the original type
     if (isSameType(expected, received)) {

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -1,29 +1,32 @@
-import { InternalOption, ParsingOptions, SimpleRecord } from './types';
+import { InternalOptions, ParsingOptions, SimpleRecord } from './types';
 import { parseJSONFile } from './utils';
 
 export function transformOptions(
   parsingOptions?: ParsingOptions
-): InternalOption[] {
-  if (!parsingOptions?.options) return [];
-  return Object.entries(parsingOptions.options).map(([name, rest]) => ({
-    name,
-    ...rest,
-  }));
+): InternalOptions {
+  if (!parsingOptions?.options) return new Map();
+  return new Map(
+    Object.entries(parsingOptions.options).reduce((acc, [name, opts]) => {
+      if (!opts) return acc;
+      acc.set(name, { ...opts, name });
+      return acc;
+    }, new Map())
+  );
 }
 
 type TransFormArgV = {
   argv: string[];
-  options: InternalOption[];
+  options?: InternalOptions;
   filePathFlag?: `--${string}`;
 };
 
 export function transformArgv<T extends SimpleRecord>({
   argv,
-  options,
+  options = new Map(),
   filePathFlag,
 }: TransFormArgV): Partial<T> {
-  const shortFlags = options.reduce((acc, curr) => {
-    if (curr.shortFlag) acc[curr.shortFlag] = curr.name;
+  const shortFlags = [...options.entries()].reduce((acc, [name, opts]) => {
+    if (opts.shortFlag) acc[opts.shortFlag] = name;
     return acc;
   }, {} as SimpleRecord);
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,7 +23,7 @@ export type ParsingOptions<
   };
 };
 
-export type InternalOption = FlagOption & { name: string };
+export type InternalOptions = Map<string, FlagOption & { name: string }>;
 
 export type SimpleRecord<T extends string = string> = Record<T, ObjectValues>;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,6 +2,14 @@ export type FlagOption = {
   required?: boolean;
   description?: string;
   shortFlag?: `-${string}`;
+  customValidator?: {
+    validate: (value: any) => boolean;
+    reason: (value: any) => string;
+  };
+  strictCustomValidator?: {
+    value: (value: unknown) => boolean;
+    reason: (value: unknown) => string;
+  };
 };
 
 export type FilePathArg = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,11 +3,7 @@ export type FlagOption = {
   description?: string;
   shortFlag?: `-${string}`;
   customValidator?: {
-    validate: (value: any) => boolean;
-    reason: (value: any) => string;
-  };
-  strictCustomValidator?: {
-    value: (value: unknown) => boolean;
+    validate: (value: unknown) => boolean;
     reason: (value: unknown) => string;
   };
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,8 +3,8 @@ export type FlagOption = {
   description?: string;
   shortFlag?: `-${string}`;
   customValidator?: {
-    validate: (value: unknown) => boolean;
-    reason: (value: unknown) => string;
+    isValid: (value: unknown) => boolean;
+    errorMessage: (value: unknown) => string;
   };
 };
 

--- a/test/help.test.ts
+++ b/test/help.test.ts
@@ -1,4 +1,5 @@
 import { displayHelp } from '../src/help';
+import { transformOptions } from '../src/transform';
 
 describe('Helper text', () => {
   it('creates helper text with descriptions', () => {
@@ -11,27 +12,24 @@ describe('Helper text', () => {
 
     const helperText = displayHelp({
       defaultValues,
-      options: [
-        {
-          name: 'id',
+      options: transformOptions({
+        options: {
+          id: {},
+          color: {
+            required: true,
+            description: 'A color',
+          },
+          withAuth: {
+            description: 'Require authentication for this action',
+            shortFlag: '-wa',
+          },
+          port: {
+            description: 'The port to listen on',
+            shortFlag: '-p',
+            required: true,
+          },
         },
-        {
-          name: 'color',
-          required: true,
-          description: 'A color',
-        },
-        {
-          name: 'withAuth',
-          description: 'Require authentication for this action',
-          shortFlag: '-wa',
-        },
-        {
-          name: 'port',
-          description: 'The port to listen on',
-          shortFlag: '-p',
-          required: true,
-        },
-      ],
+      }),
       filePathArg: {
         longFlag: '--config',
         description: 'The config file to use',
@@ -63,7 +61,6 @@ describe('Helper text', () => {
   it('creates helper text for file flag only', () => {
     const helperText = displayHelp({
       defaultValues: {},
-      options: [],
       filePathArg: { longFlag: '--config' },
     });
     expect(helperText).toMatchInlineSnapshot(`
@@ -79,8 +76,7 @@ describe('Helper text', () => {
       withAuth: false,
       port: 999,
     };
-    const helperText = displayHelp({ defaultValues, options: [] });
-
+    const helperText = displayHelp({ defaultValues });
     expect(helperText).toMatchInlineSnapshot(`"Usage"`);
   });
 });

--- a/test/integration/index.test.js
+++ b/test/integration/index.test.js
@@ -6,7 +6,7 @@ process.argv.push('-gp', '--config', 'github.json');
 
 test('Integration and docs', async (t) => {
   await t.test('full example', async () => {
-    // Default values. These will be used as defaults/fallback
+    // Default values. They will be used as defaults/fallback
     const defaultValues = {
       username: '',
       hasGithubProfile: false,
@@ -28,6 +28,15 @@ test('Integration and docs', async (t) => {
             required: true,
             // For the help() command
             description: 'Your Github username',
+            // A custom validator that will receive the value for
+            // "username" and returns a boolean
+            customValidator: {
+              isValid: (value) =>
+                typeof value === 'string' && /\w+/.test(value),
+              // The error message for when validation fails
+              errorMessage: (value) =>
+                `${value} is not a valid GitHub username`,
+            },
           },
           hasGithubProfile: {
             description: 'Indicate whether you have a Github profile',

--- a/test/parse.test.ts
+++ b/test/parse.test.ts
@@ -13,14 +13,13 @@ describe('Object literal parsing', () => {
   };
 
   it('returns default config if no args', async () => {
-    const c1 = await parse({ defaultValues, options: [], input: {} });
+    const c1 = await parse({ defaultValues, input: {} });
     expect(c1).toStrictEqual(defaultValues);
   });
 
   it('overwrites default values', async () => {
     const c1 = await parse({
       defaultValues,
-      options: [],
       input: {
         stringProp: 'hello',
         boolProp: true,
@@ -34,7 +33,6 @@ describe('Object literal parsing', () => {
     });
     const c2 = await parse({
       defaultValues,
-      options: [],
       input: {
         stringProp: 'hello',
       },
@@ -49,7 +47,6 @@ describe('Object literal parsing', () => {
     const c = await parse({
       defaultValues,
       input: { unknownProp: 'hello' } as unknown as typeof defaultValues,
-      options: [],
     });
     expect(c).toStrictEqual({
       ...defaultValues,
@@ -62,7 +59,6 @@ describe('Object literal parsing', () => {
       await parse({
         defaultValues,
         input: { boolProp: {} } as unknown as typeof defaultValues,
-        options: [],
       });
     } catch (e) {
       expect(e).toBeInstanceOf(ValidationError);
@@ -85,16 +81,19 @@ describe('Parsing with options', () => {
     const args: Parameters<typeof parse>[0] = {
       defaultValues,
       input: { stringProp: 'goodbye' },
-      options: [
-        {
-          name: 'stringProp',
-          required: true,
-          customValidator: {
-            validate: (v) => typeof v === 'string',
-            reason: () => "whoops this shouldn't happen",
+      options: new Map([
+        [
+          'stringProp',
+          {
+            name: 'stringProp',
+            required: true,
+            customValidator: {
+              validate: (v) => typeof v === 'string',
+              reason: () => "whoops this shouldn't happen",
+            },
           },
-        },
-      ],
+        ],
+      ]),
     };
     await expect(parse(args)).resolves.toStrictEqual({
       ...defaultValues,
@@ -107,7 +106,9 @@ describe('Parsing with options', () => {
     const args: Parameters<typeof parse>[0] = {
       defaultValues,
       input: {},
-      options: [{ name: 'stringProp', required: true }],
+      options: new Map([
+        ['stringProp', { name: 'stringProp', required: true }],
+      ]),
     };
     try {
       await parse(args);
@@ -122,16 +123,19 @@ describe('Parsing with options', () => {
     const args: Parameters<typeof parse>[0] = {
       defaultValues,
       input: { stringProp: 'goodbye' },
-      options: [
-        {
-          name: 'stringProp',
-          required: true,
-          customValidator: {
-            validate: (v) => v === 'hello',
-            reason: (v) => `did get "${v}", expected hello`,
+      options: new Map([
+        [
+          'stringProp',
+          {
+            name: 'stringProp',
+            required: true,
+            customValidator: {
+              validate: (v) => v === 'hello',
+              reason: (v) => `did get "${v}", expected hello`,
+            },
           },
-        },
-      ],
+        ],
+      ]),
     };
     try {
       await parse(args);

--- a/test/parse.test.ts
+++ b/test/parse.test.ts
@@ -85,7 +85,16 @@ describe('Parsing with options', () => {
     const args: Parameters<typeof parse>[0] = {
       defaultValues,
       input: { stringProp: 'goodbye' },
-      options: [{ name: 'stringProp', required: true }],
+      options: [
+        {
+          name: 'stringProp',
+          required: true,
+          customValidator: {
+            validate: (v) => v === 'goodbye',
+            reason: () => "whoops this shouldn't happen",
+          },
+        },
+      ],
     };
     await expect(parse(args)).resolves.toStrictEqual({
       ...defaultValues,
@@ -105,6 +114,30 @@ describe('Parsing with options', () => {
     } catch (e) {
       expect(e).toBeInstanceOf(ValidationError);
       expect(e).toHaveProperty('message', '"stringProp" is required');
+    }
+  });
+
+  it('rejects for failed custom validation', async () => {
+    expect.assertions(2);
+    const args: Parameters<typeof parse>[0] = {
+      defaultValues,
+      input: { stringProp: 'goodbye' },
+      options: [
+        {
+          name: 'stringProp',
+          required: true,
+          customValidator: {
+            validate: (v) => v === 'hello',
+            reason: (v) => `did get "${v}", expected hello`,
+          },
+        },
+      ],
+    };
+    try {
+      await parse(args);
+    } catch (e) {
+      expect(e).toBeInstanceOf(ValidationError);
+      expect(e).toHaveProperty('message', 'did get "goodbye", expected hello');
     }
   });
 });

--- a/test/parse.test.ts
+++ b/test/parse.test.ts
@@ -88,8 +88,8 @@ describe('Parsing with options', () => {
             name: 'stringProp',
             required: true,
             customValidator: {
-              validate: (v) => typeof v === 'string',
-              reason: () => "whoops this shouldn't happen",
+              isValid: (v) => typeof v === 'string',
+              errorMessage: () => "whoops this shouldn't happen",
             },
           },
         ],
@@ -130,8 +130,8 @@ describe('Parsing with options', () => {
             name: 'stringProp',
             required: true,
             customValidator: {
-              validate: (v) => v === 'hello',
-              reason: (v) => `did get "${v}", expected hello`,
+              isValid: (v) => v === 'hello',
+              errorMessage: (v) => `did get "${v}", expected hello`,
             },
           },
         ],

--- a/test/parse.test.ts
+++ b/test/parse.test.ts
@@ -90,7 +90,7 @@ describe('Parsing with options', () => {
           name: 'stringProp',
           required: true,
           customValidator: {
-            validate: (v) => v === 'goodbye',
+            validate: (v) => typeof v === 'string',
             reason: () => "whoops this shouldn't happen",
           },
         },

--- a/test/transform.test.ts
+++ b/test/transform.test.ts
@@ -12,24 +12,32 @@ describe('External options transformer', () => {
         },
       },
     });
-    expect(res).toStrictEqual([
-      {
-        name: 'test',
-        required: true,
-      },
-      {
-        description: 'another property',
-        name: 'test2',
-      },
-    ]);
-    expect(transformOptions({})).toStrictEqual([]);
-    expect(transformOptions()).toStrictEqual([]);
+    expect(res).toStrictEqual(
+      new Map([
+        [
+          'test',
+          {
+            name: 'test',
+            required: true,
+          },
+        ],
+        [
+          'test2',
+          {
+            description: 'another property',
+            name: 'test2',
+          },
+        ],
+      ])
+    );
+    expect(transformOptions({})).toStrictEqual(new Map());
+    expect(transformOptions()).toStrictEqual(new Map());
   });
 });
 
 describe('Argv transformer', () => {
   it('parses empty', async () => {
-    const c = transformArgv({ argv: [], options: [] });
+    const c = transformArgv({ argv: [] });
     expect(c).toStrictEqual({});
   });
 
@@ -43,7 +51,6 @@ describe('Argv transformer', () => {
         '123',
         '--boolProp2',
       ],
-      options: [],
     },
     {
       argv: [
@@ -54,7 +61,6 @@ describe('Argv transformer', () => {
         '--numProp',
         '123',
       ],
-      options: [],
     },
     {
       argv: [
@@ -65,7 +71,6 @@ describe('Argv transformer', () => {
         'hello from node',
         '--boolProp2',
       ],
-      options: [],
     },
     {
       argv: [
@@ -76,7 +81,6 @@ describe('Argv transformer', () => {
         'hello from node',
         '--boolProp2',
       ],
-      options: [],
     },
   ];
   orders.forEach((variant, idx) => {
@@ -112,10 +116,10 @@ describe('Argv transformer with options', () => {
         '-p',
         'MyPassword',
       ],
-      options: [
-        { name: 'secret', shortFlag: '-s' },
-        { name: 'password', shortFlag: '-p' },
-      ],
+      options: new Map([
+        ['secret', { name: 'secret', shortFlag: '-s' }],
+        ['password', { name: 'password', shortFlag: '-p' }],
+      ]),
     });
     expect(c).toStrictEqual({
       secret: 123,
@@ -125,14 +129,13 @@ describe('Argv transformer with options', () => {
     });
   });
   it('transforms empty', async () => {
-    const c = transformArgv({ argv: ['-s', '123'], options: [] });
+    const c = transformArgv({ argv: ['-s', '123'] });
     expect(c).toStrictEqual({});
   });
   it('parses from simple JSON files', async () => {
-    transformArgv({ argv: [], options: [] });
+    transformArgv({ argv: [] });
     const c = transformArgv({
       argv: ['--config', 'test/config.json'],
-      options: [],
       filePathFlag: '--config',
     });
     expect(c).toStrictEqual({
@@ -140,11 +143,10 @@ describe('Argv transformer with options', () => {
     });
   });
   it('throws for invalid files', async () => {
-    transformArgv({ argv: [], options: [] });
+    transformArgv({ argv: [] });
     expect(() => {
       transformArgv({
         argv: ['--config', 'config.json'],
-        options: [],
         filePathFlag: '--config',
       });
     }).toThrow('config.json is not a valid JSON file');


### PR DESCRIPTION
- Allow an optional custom validation function per flag/option
- Cleanup internal API and use a `Map` instead of an object literal for handling configuration