### PR TITLE
fix: remove redundant help command text

### DIFF
--- a/src/help.ts
+++ b/src/help.ts
@@ -43,7 +43,6 @@ export const displayHelp = ({
 
     str += `${tab}${shortFlag ? `${shortFlag}, ` : ''}`;
     str += `--${name}`;
-    str += isBoolean ? '' : ` <${name}>`;
     str += ` [${typeof defaultValues[name]}]`;
     str += description ? `\n${tab}` + description : '';
     str += isLast ? '' : '\n\n';

--- a/test/help.test.ts
+++ b/test/help.test.ts
@@ -41,14 +41,14 @@ describe('Helper text', () => {
       "CLI options
 
       Required
-         --color <color> [string]
+         --color [string]
          A color
 
-         -p, --port <port> [number]
+         -p, --port [number]
          The port to listen on
 
       Optional
-         --id <id> [string]
+         --id [string]
 
          -wa, --withAuth [boolean]
          Require authentication for this action


### PR DESCRIPTION
Previously, the `help` utility function to would print available [long flag names](https://github.com/eegli/tinyparse#glossary-and-support) twice. This has been fixed.

```bash
   -p, --port <port> [number]
   The port to listen on
```

is now

```bash
   -p, --port [number]
   The port to listen on
```