### PR TITLE
fix: respect decamelization in error messages

### DIFF
--- a/src/help.ts
+++ b/src/help.ts
@@ -1,6 +1,6 @@
 import { Options } from './options';
 import { HelpOptions } from './types';
-import { decamelize } from './utils';
+import Utils from './utils';
 
 interface InternalHelpOptions extends HelpOptions {
   options: Options;
@@ -32,25 +32,28 @@ export const displayHelp = ({
   sortedOptions.forEach(
     ([name, { description, required, shortFlag, _type }], idx) => {
       const isLast = idx === sortedOptions.length - 1;
-      name = options.shouldDecamelize ? decamelize(name) : name;
+      name = options.shouldDecamelize ? Utils.decamelize(name) : name;
 
       if (optionalFlag && !required) {
         str += 'Optional flags\n';
         optionalFlag = false;
       }
 
-      str += `${tab}${shortFlag ? `${shortFlag}, ` : ''}`;
+      str += tab;
+      if (shortFlag) str += `${shortFlag}, `;
       str += `--${name}`;
       str += ` [${_type}]`;
-      str += description ? `\n${tab}` + description : '';
-      str += isLast ? '' : '\n\n';
+      if (description) str += `\n${tab}${description}`;
+      if (!isLast) str += '\n\n';
     }
   );
 
-  if (options.filePathFlag) {
-    const { longFlag, description } = options.filePathFlag;
-    str += `\n\n${tab}${longFlag} [string]\n`;
-    str += description ? `${tab}${description}\n` : '';
+  if (options.filePathArg) {
+    const { longFlag, shortFlag, description } = options.filePathArg;
+    str += `\n\n${tab}`;
+    if (shortFlag) str += `-${shortFlag}, `;
+    str += `--${longFlag} [string]\n`;
+    if (description) str += `${tab}${description}\n`;
   }
   return str;
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,10 +28,11 @@ export function createParser<T extends SimpleRecord>(
   async function parse(input?: string[]): Promise<WithPositionalArgs<T>>;
   async function parse(input: Partial<T> | string[] = {}): Promise<T> {
     if (Array.isArray(input)) {
-      const [transformed, positionals] = parser.transform(input, {
-        aliases: options.aliases,
-        filePathFlag: options.filePathFlag?.longFlag,
-      });
+      const [transformed, positionals] = parser.transform(
+        input,
+        options.aliases,
+        options.filePathArg
+      );
       const parsed = await parser.parse(transformed, options, true);
       return parser.build(parsed, positionals);
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,10 +32,10 @@ export function createParser<T extends SimpleRecord>(
         aliases: options.aliases,
         filePathFlag: options.filePathFlag?.longFlag,
       });
-      const parsed = await parser.parse(transformed, options.options);
+      const parsed = await parser.parse(transformed, options, true);
       return parser.build(parsed, positionals);
     }
-    return parser.parse(input, options.options);
+    return parser.parse(input, options, false);
   }
 
   return {

--- a/src/options.ts
+++ b/src/options.ts
@@ -74,4 +74,8 @@ export class Options {
   public entries() {
     return this._opts.entries();
   }
+
+  public get(key: string) {
+    return this._opts.get(key);
+  }
 }

--- a/src/options.ts
+++ b/src/options.ts
@@ -1,17 +1,19 @@
 import {
   FilePathArg,
+  Flag,
+  FlagAlias,
   InternalOptions,
   ParserOptions,
   SimpleRecord,
 } from './types';
-import { decamelize } from './utils';
+import Utils from './utils';
 
 export class Options {
   private readonly _opts: InternalOptions = new Map();
-  private readonly _aliases: Map<string, string> = new Map();
+  private readonly _aliases: Map<FlagAlias, Flag> = new Map();
 
   public readonly shouldDecamelize: boolean;
-  public readonly filePathFlag?: FilePathArg;
+  public readonly filePathArg?: FilePathArg;
 
   constructor(defaults: SimpleRecord, options: ParserOptions = {}) {
     // Merge option keys/flags with user-provided options
@@ -22,7 +24,7 @@ export class Options {
 
     // Global options
     this.shouldDecamelize = !!options.decamelize;
-    this.filePathFlag = options.filePathArg;
+    this.filePathArg = options.filePathArg;
 
     // Create alias map
     this._createAliasMap();
@@ -36,7 +38,7 @@ export class Options {
         opts.shortFlag = shortFlag;
       }
       if (this.shouldDecamelize) {
-        const decamelized = decamelize(key);
+        const decamelized = Utils.decamelize(key);
         if (decamelized !== key) {
           const longFlag = this._makeFlag(decamelized, 'long');
           this._aliases.set(longFlag, key);
@@ -44,38 +46,37 @@ export class Options {
       }
     }
 
-    if (this.filePathFlag) {
-      this.filePathFlag.longFlag = this._makeFlag(
-        this.filePathFlag.longFlag,
-        'long'
+    if (this.filePathArg) {
+      this.filePathArg.longFlag = this._removeFlagPrefix(
+        this.filePathArg.longFlag
       );
     }
-    if (this.filePathFlag?.shortFlag) {
-      this.filePathFlag.shortFlag = this._makeFlag(
-        this.filePathFlag.shortFlag,
-        'short'
+    if (this.filePathArg?.shortFlag) {
+      this.filePathArg.shortFlag = this._removeFlagPrefix(
+        this.filePathArg.shortFlag
       );
     }
   }
 
-  private _makeFlag(flag: string, type: 'long' | 'short') {
+  private _removeFlagPrefix(flag: string): Flag {
+    return flag.trim().replace(/^-+/, '');
+  }
+
+  private _makeFlag(flag: string, type: 'long' | 'short'): FlagAlias {
+    flag = this._removeFlagPrefix(flag);
     const prefix = type === 'long' ? '--' : '-';
-    flag = flag.trim().replace(/^-+/, '');
     return `${prefix}${flag}`;
-  }
-
-  public get aliases() {
-    return this._aliases;
-  }
-  public get options() {
-    return this._opts;
   }
 
   public entries() {
     return this._opts.entries();
   }
 
-  public get(key: string) {
-    return this._opts.get(key);
+  public get aliases() {
+    return this._aliases;
+  }
+
+  public get options() {
+    return this._opts;
   }
 }

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1,69 +1,123 @@
 import { ValidationError } from './error';
-import { InternalOptions, SimpleRecord, Value } from './types';
-import { isSameType } from './utils';
+import { Options } from './options';
+import { SimpleRecord, Value } from './types';
+import { decamelize, isSameType } from './utils';
+
+enum ErrorType {
+  MissingRequired,
+  InvalidType,
+  Custom,
+}
+
+type ErrorArgs =
+  | { type: ErrorType.MissingRequired; value: string }
+  | {
+      type: ErrorType.InvalidType;
+      value: string;
+      expectedType: string;
+      receivedType: string;
+    }
+  | { type: ErrorType.Custom; value: string };
 
 export class Parser<T extends SimpleRecord> {
   private readonly _requiredSym = Symbol('isRequired');
+  private _shouldDecamelizeError = false;
 
   constructor(private readonly _defaultValues: T) {}
 
+  private _throw(p: ErrorArgs): never {
+    const { type } = p;
+    const value = this._shouldDecamelizeError ? decamelize(p.value) : p.value;
+
+    switch (type) {
+      case ErrorType.MissingRequired:
+        throw new ValidationError(`"${value}" is required`);
+      case ErrorType.InvalidType:
+        throw new ValidationError(
+          `Invalid type for "${value}". Expected ${p.expectedType}, got ${p.receivedType}`
+        );
+      case ErrorType.Custom:
+        throw new ValidationError(value);
+    }
+  }
+
   // eslint-disable-next-line require-await
-  public async parse(input: Partial<T>, options: InternalOptions): Promise<T> {
+  public async parse(
+    input: Partial<T>,
+    options: Options,
+    fromArgv: boolean
+  ): Promise<T> {
+    this._shouldDecamelizeError = fromArgv && options.shouldDecamelize;
+
     const config = new Map<string, Value | symbol>(
       Object.entries(this._defaultValues)
     );
 
-    const requiredArgs = Array.from(options.entries())
+    const requiredFlags = Array.from(options.entries())
       .filter(([, options]) => options.required)
       .map(([key]) => key);
 
-    // For each required argument, replace its value temporarily
+    // For each required flag, replace its value temporarily
     // with a symbol
-    requiredArgs.forEach((arg) => {
-      config.set(arg, this._requiredSym);
+    requiredFlags.forEach((flag) => {
+      config.set(flag, this._requiredSym);
     });
 
-    for (const inputPair of Object.entries(input)) {
-      const [arg] = inputPair;
-      let [, argVal] = inputPair;
+    for (const flagValuePair of Object.entries(input)) {
+      const [flag] = flagValuePair;
+      let [, flagValue] = flagValuePair;
 
-      if (!config.has(arg)) continue;
+      if (!config.has(flag)) continue;
 
-      const expectedType = typeof this._defaultValues[arg];
+      const expectedType = typeof this._defaultValues[flag];
 
       // Iif the expected type is a number, try to convert the value
       if (expectedType === 'number') {
-        argVal = Number(argVal);
+        flagValue = Number(flagValue);
       }
 
-      const receivedType = typeof argVal;
-      const customValidator = options.get(arg)?.customValidator;
+      const receivedType = typeof flagValue;
+      const customValidator = options.get(flag)?.customValidator;
+
+      let argNameToThrow = flag;
+      if (fromArgv && options.shouldDecamelize) {
+        argNameToThrow = decamelize(flag);
+      }
 
       // Custom validation
       if (customValidator) {
-        if (customValidator.isValid(argVal)) {
-          config.set(arg, argVal);
+        if (customValidator.isValid(flagValue)) {
+          config.set(flag, flagValue);
         } else {
-          throw new ValidationError(customValidator.errorMessage(argVal));
+          this._throw({
+            type: ErrorType.Custom,
+            value: customValidator.errorMessage(flagValue),
+          });
         }
       }
 
       // Default validation (based on types) -  The received type must
       // corresponds to the original type
       if (isSameType(expectedType, receivedType)) {
-        config.set(arg, argVal);
+        config.set(flag, flagValue);
       } else {
-        throw new ValidationError(
-          `Invalid type for "${arg}". Expected ${expectedType}, got ${receivedType}`
-        );
+        this._throw({
+          type: ErrorType.InvalidType,
+          value: flag,
+          expectedType,
+          receivedType,
+        });
       }
     }
 
     // Check if all required arguments have been defined or if the
     // temporary value is still there
-    requiredArgs.forEach((arg) => {
-      if (config.get(arg) === this._requiredSym) {
-        throw new ValidationError(`"${arg}" is required`);
+    requiredFlags.forEach((flag) => {
+      if (config.get(flag) === this._requiredSym) {
+        this._throw({
+          type: ErrorType.MissingRequired,
+          value: flag,
+        });
       }
     }, <string[]>[]);
 

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1,7 +1,7 @@
 import { ValidationError } from './error';
 import { Options } from './options';
 import { SimpleRecord, Value } from './types';
-import { decamelize, isSameType } from './utils';
+import Utils from './utils';
 
 enum ErrorType {
   MissingRequired,
@@ -27,7 +27,9 @@ export class Parser<T extends SimpleRecord> {
 
   private _throw(p: ErrorArgs): never {
     const { type } = p;
-    const value = this._shouldDecamelizeError ? decamelize(p.value) : p.value;
+    const value = this._shouldDecamelizeError
+      ? Utils.decamelize(p.value)
+      : p.value;
 
     switch (type) {
       case ErrorType.MissingRequired:
@@ -77,11 +79,11 @@ export class Parser<T extends SimpleRecord> {
       }
 
       const receivedType = typeof flagValue;
-      const customValidator = options.get(flag)?.customValidator;
+      const customValidator = options.options.get(flag)?.customValidator;
 
       let argNameToThrow = flag;
       if (fromArgv && options.shouldDecamelize) {
-        argNameToThrow = decamelize(flag);
+        argNameToThrow = Utils.decamelize(argNameToThrow);
       }
 
       // Custom validation
@@ -98,7 +100,7 @@ export class Parser<T extends SimpleRecord> {
 
       // Default validation (based on types) -  The received type must
       // corresponds to the original type
-      if (isSameType(expectedType, receivedType)) {
+      if (Utils.isSameType(expectedType, receivedType)) {
         config.set(flag, flagValue);
       } else {
         this._throw({

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,17 @@
+type _ = Record<never, never>;
+
+// Flags do NOT start with a single or double dash
+export type Flag = string & _;
+
+// Flag aliases start with a single or double dash
+export type FlagAlias = string & _;
+
+export type FlagAliasMap = Map<FlagAlias, Flag>;
+
 interface ArgOption {
   required?: boolean;
   description?: string;
-  shortFlag?: string;
+  shortFlag?: Flag;
   customValidator?: {
     isValid: (value: unknown) => boolean;
     errorMessage: (value: unknown) => string;
@@ -13,8 +23,8 @@ export interface InternalArgOption extends ArgOption {
 }
 
 export type FilePathArg = {
-  longFlag: string;
-  shortFlag?: string;
+  longFlag: Flag;
+  shortFlag?: Flag;
   description?: string;
 };
 
@@ -39,7 +49,7 @@ export type PositionalArgs = string[];
 
 export type WithPositionalArgs<T> = T & { _: PositionalArgs };
 
-export type InternalOptions = Map<string, InternalArgOption>;
+export type InternalOptions = Map<Flag, InternalArgOption>;
 
 export type SimpleRecord = Record<string, Value>;
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,22 +1,32 @@
-import { readFileSync } from 'fs';
 import { ValidationError } from './error';
 import _decamelize from './lib/decamelize';
 
+type ReadFileSync = typeof import('fs').readFileSync;
+
 const allowedTypes = new Set(['string', 'number', 'boolean']);
 
-export function isSameType(type: string, reference: string): boolean {
-  return allowedTypes.has(type) && type === reference;
-}
+export default class Utils {
+  public static isSameType(type: string, reference: string): boolean {
+    return allowedTypes.has(type) && type === reference;
+  }
 
-export function decamelize(value: string) {
-  return _decamelize(value, { separator: '-' });
-}
+  public static decamelize(value: string) {
+    return _decamelize(value, { separator: '-' });
+  }
 
-export function parseJSONFile(path: string): [string, unknown][] {
-  try {
-    const file = readFileSync(path, { encoding: 'utf8' });
-    return Object.entries(JSON.parse(file));
-  } catch (error) {
-    throw new ValidationError(`${path} is not a valid JSON file`);
+  public static parseJSONFile(path: string): [string, unknown][] {
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const readFileSync = require('fs').readFileSync as ReadFileSync;
+      const file = readFileSync(path, { encoding: 'utf8' });
+      return Object.entries(JSON.parse(file));
+    } catch (error) {
+      throw new ValidationError(`${path} is not a valid JSON file`);
+    }
+  }
+
+  public static getFlagType(value: string): [boolean, boolean] {
+    const isShortFlag = value[0] === '-';
+    return [isShortFlag, isShortFlag && value[1] === '-'];
   }
 }

--- a/test/argv.test.ts
+++ b/test/argv.test.ts
@@ -3,10 +3,7 @@ import { ArgvParser } from '../src/argv';
 describe('Argv transformer', () => {
   it('parses empty', () => {
     const parser = new ArgvParser({});
-    expect(parser.transform([], { aliases: new Map() })).toStrictEqual([
-      {},
-      [],
-    ]);
+    expect(parser.transform([], new Map())).toStrictEqual([{}, []]);
   });
 
   const orders = [
@@ -54,11 +51,7 @@ describe('Argv transformer', () => {
   orders.forEach((variant, idx) => {
     it('works with order ' + idx, () => {
       const parser = new ArgvParser({});
-      expect(
-        parser.transform(variant.argv, {
-          aliases: new Map(),
-        })
-      ).toStrictEqual([
+      expect(parser.transform(variant.argv, new Map())).toStrictEqual([
         {
           boolProp1: true,
           stringProp: 'hello from node',
@@ -96,12 +89,10 @@ describe('Argv transformer with options', () => {
         '--doubleQuotes',
         "'-this is a string'",
       ],
-      {
-        aliases: new Map([
-          ['-p', 'password'],
-          ['--input-message', 'inputMessage'],
-        ]),
-      }
+      new Map([
+        ['-p', 'password'],
+        ['--input-message', 'inputMessage'],
+      ])
     );
     expect(transformed).toStrictEqual([
       {
@@ -117,10 +108,11 @@ describe('Argv transformer with options', () => {
   });
   it('parses from simple JSON files', () => {
     const parser = new ArgvParser({});
-    const transformed = parser.transform(['--config', 'test/config.json'], {
-      aliases: new Map([['-p', '--password']]),
-      filePathFlag: '--config',
-    });
+    const transformed = parser.transform(
+      ['--config', 'test/config.json'],
+      new Map([['-p', '--password']]),
+      { longFlag: 'config' }
+    );
     expect(transformed).toStrictEqual([
       {
         username: 'eegli',
@@ -133,10 +125,11 @@ describe('Argv transformer with options', () => {
     const parser = new ArgvParser({});
 
     expect(() => {
-      parser.transform(['--config', 'config.json'], {
-        aliases: new Map([['-p', '--password']]),
-        filePathFlag: '--config',
-      });
+      parser.transform(
+        ['--config', 'config.json'],
+        new Map([['-p', '--password']]),
+        { longFlag: 'config' }
+      );
     }).toThrow('config.json is not a valid JSON file');
   });
 });

--- a/test/help.test.ts
+++ b/test/help.test.ts
@@ -11,7 +11,8 @@ describe('Helper text', () => {
 
     const { help } = createParser(defaultValues, {
       filePathArg: {
-        longFlag: '--config',
+        longFlag: '-config',
+        shortFlag: '-c',
         description: 'The config file to use',
       },
       options: {
@@ -51,7 +52,7 @@ describe('Helper text', () => {
          -wa, --withAuth [boolean]
          Require authentication for this action
 
-         --config [string]
+         -c, --config [string]
          The config file to use
       "
     `);

--- a/test/options.test.ts
+++ b/test/options.test.ts
@@ -20,29 +20,28 @@ describe('Options', () => {
       ['b', { _type: 'number' }],
     ]);
   });
-  test('flag conversion', () => {
-    const options = new Options(
-      { one: 0, two: 0 },
-      {
-        options: { one: { shortFlag: '-o' }, two: { shortFlag: 't' } },
-        filePathArg: {
-          longFlag: '--file',
-          shortFlag: 'f',
-        },
-      }
-    );
-    expect(options.filePathFlag).toStrictEqual({
-      longFlag: '--file',
-      shortFlag: '-f',
+  test('file path flag conversion', () => {
+    [
+      ['file', 'f'],
+      ['--file', '--f'],
+      ['-file', '-f'],
+    ].forEach(([longFlag, shortFlag]) => {
+      const options = new Options(
+        {},
+        {
+          filePathArg: {
+            longFlag,
+            shortFlag,
+          },
+        }
+      );
+      expect(options.filePathArg).toStrictEqual({
+        longFlag: 'file',
+        shortFlag: 'f',
+      });
     });
-    expect(options.aliases).toStrictEqual(
-      new Map([
-        ['-o', 'one'],
-        ['-t', 'two'],
-      ])
-    );
   });
-  test('aliases, trims short flags', () => {
+  test('alias construction with flag conversion', () => {
     const options = new Options(
       { firstfirst: 0, secondSecond: 0, Thirdthird: 0 },
       {
@@ -52,19 +51,15 @@ describe('Options', () => {
         },
         decamelize: true,
         filePathArg: {
-          longFlag: '--file',
+          longFlag: ' --file',
         },
       }
     );
     expect(options.shouldDecamelize).toBeTruthy();
-    expect(options.filePathFlag).toStrictEqual({ longFlag: '--file' });
-    expect(options.aliases).toStrictEqual(
-      new Map([
-        ['-f', 'firstfirst'],
-        ['-second', 'secondSecond'],
-        ['--second-second', 'secondSecond'],
-        ['--thirdthird', 'Thirdthird'],
-      ])
-    );
+    expect(options.filePathArg).toStrictEqual({ longFlag: 'file' });
+    expect(options.aliases.get('-f')).toBe('firstfirst');
+    expect(options.aliases.get('-second')).toBe('secondSecond');
+    expect(options.aliases.get('--second-second')).toBe('secondSecond');
+    expect(options.aliases.get('--thirdthird')).toBe('Thirdthird');
   });
 });

--- a/test/parse.test.ts
+++ b/test/parse.test.ts
@@ -170,6 +170,28 @@ describe('Parsing with options', () => {
     await expect(parse(input)).resolves.toStrictEqual(expected);
   });
 
+  it('throws correct decamelized error message depending on input', async () => {
+    const { parse } = createParser(defaultValues, {
+      decamelize: true,
+      options: {
+        stringProp: {
+          required: true,
+        },
+      },
+    });
+    expect.assertions(2);
+    try {
+      await parse([]);
+    } catch (e) {
+      expect(e).toHaveProperty('message', '"string-prop" is required');
+    }
+    try {
+      await parse({});
+    } catch (e) {
+      expect(e).toHaveProperty('message', '"stringProp" is required');
+    }
+  });
+
   it('handles short flags', async () => {
     const { parse } = createParser(defaultValues, {
       decamelize: true,


### PR DESCRIPTION
Previously, when decamelization had been enabled, flags in error messages would still appear in the original format, e.g.: "`someProp` is required!". With this change, when CLI arguments are parsed and decamelization is enabled, the decamelized format is used for error messages (e.g.,  "`some-prop` is required!").

Decamelization still has no effect on the error messages caused by parsing object literals.